### PR TITLE
Transfer to membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,6 @@ For access to the /me endpoints, valid GU_U and SC_GU_U must be provided in the 
     GET /user-attributes/USER_ID/membership
     GET /user-attributes/me/membership
  
-### Write endpoints
-    
-    PUT /user-attributes/USER_ID/membership
-    PUT /user-attributes/me/membership
-    
 The request body must contain JSON in the following structure:
 
     {

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Error responses:
 
 Ensure that your ~/.aws/credentials file contains the following:
 
-    [identity]
+    [membership]
     aws_access_key_id=YOUR_ACCESS_KEY
     aws_secret_access_key=YOUR_SECRET_KEY
     
@@ -65,15 +65,17 @@ These credentials are required for accessing the DynamoDB table. When running te
 
 To start the service use:
 
-    sbt membership-attribute-service/run
+```
+    $ sbt
+    > project membership-attribute-service
+    > devrun
+```
 
-The service will be starting on Play's default port of 9000 and use the MembershipAttributes-CODE DynamoDB table.
+The service will be starting on 9100 and use the MembershipAttributes-DEV DynamoDB table.
 
 ## Metrics and Logs
 
 There is a Membership Attributes Service radiator. This uses standard ELB and DynamoBB CloudWatch metrics for the CloudFormation stack in the chosen stage.
-
-Logs are sent to Cloud Watch in a log group named identity-membership-attribute-service-STAGE. Within the log groups there will be logs for each EC2 instance.
 
 ## Provisioning
 

--- a/cloudformation/membership-attribute-service.json
+++ b/cloudformation/membership-attribute-service.json
@@ -13,7 +13,7 @@
     "Stage": {
       "Description": "Environment name",
       "Type": "String",
-      "AllowedValues": [ "CODE", "PROD" ]
+      "Default" : "PROD"
     },
     "InstanceType": {
       "Description": "EC2 instance type",
@@ -63,12 +63,12 @@
     "VpcId": {
       "Description": "ID of the VPC onto which to launch the application",
       "Type": "AWS::EC2::VPC::Id",
-      "Default": "vpc-0b86566e"
+      "Default": "vpc-e6e00183"
     },
     "VpcSubnets" : {
       "Description": "Subnets to use in VPC",
       "Type": "CommaDelimitedList",
-      "Default": "subnet-a774fdc2,subnet-bc09bfcb,subnet-efa369b6"
+      "Default": "subnet-cb91ae8d,subnet-a7b74ac2,subnet-179e8063"
     },
     "AmiId": {
       "Description": "Custom AMI to use for instances, created using Packer",
@@ -79,26 +79,17 @@
   "Mappings": {
     "StageVariables": {
       "PROD": {
-        "AutoscalingNotificationsARN": "arn:aws:sns:eu-west-1:942464564246:AutoscalingNotificationsPROD",
         "LatencyAlarmThreshold": 0.5,
         "LatencyAlarmPeriod": 60,
         "NotificationAlarmPeriod": 1200,
         "InstanceName": "PROD:membership-attribute-service",
         "DynamoDBTable": "arn:aws:dynamodb:*:*:table/MembershipAttributes-PROD"
-      },
-      "CODE": {
-        "AutoscalingNotificationsARN": "arn:aws:sns:eu-west-1:942464564246:AutoscalingNotificationsCODE",
-        "LatencyAlarmThreshold": 5,
-        "LatencyAlarmPeriod": 1200,
-        "NotificationAlarmPeriod": 1200,
-        "InstanceName": "CODE:membership-attribute-service",
-        "DynamoDBTable": "arn:aws:dynamodb:*:*:table/MembershipAttributes-CODE"
       }
     }
   },
 
   "Resources": {
-    "IdentityRole": {
+    "MembershipRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -116,11 +107,6 @@
 
           "PolicyDocument": {
             "Statement": [
-              {
-                "Effect": "Allow",
-                "Action": "s3:GetObject",
-                "Resource": "arn:aws:s3:::gu-identity-*/*"
-              },
               {
                 "Effect": "Allow",
                 "Action": "s3:GetObject",
@@ -176,7 +162,7 @@
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
         "Path": "/",
-        "Roles": [ {"Ref": "IdentityRole"} ]
+        "Roles": [ {"Ref": "MembershipRole"} ]
       }
     },
 
@@ -251,7 +237,7 @@
           },
           {
             "Key": "Stack",
-            "Value": "identity",
+            "Value": "membership",
             "PropagateAtLaunch": "true"
           },
           {
@@ -270,17 +256,6 @@
             "PropagateAtLaunch": "true"
           }
         ],
-        "NotificationConfiguration" : {
-          "TopicARN" : {
-            "Fn::FindInMap": ["StageVariables", {
-              "Ref": "Stage"
-            }, "AutoscalingNotificationsARN"]
-          },
-          "NotificationTypes":  [
-            "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
-            "autoscaling:EC2_INSTANCE_TERMINATE_ERROR"
-          ]
-        },
         "VPCZoneIdentifier": {
           "Ref": "VpcSubnets"
         }
@@ -303,23 +278,17 @@
           "Fn::Base64": {
             "Fn::Join": ["", [
               "#!/bin/bash -ev\n",
-
-              "export IDENTITY_stage='", {
-                "Ref": "Stage"
-              }, "'\n",
-
-              "aws s3 cp s3://gu-identity-dist/set-ssh-keys.sh .\n",
-              "chmod +x set-ssh-keys.sh\n",
-              "./set-ssh-keys.sh\n",
-
-              "aws s3 cp s3://gu-identity-dist/cwlogs-setup.sh .\n",
-              "chmod +x cwlogs-setup.sh\n",
-              "./cwlogs-setup.sh\n",
+              "aws s3 cp s3://gu-membership-attribute-service-dist/set-env.sh .\n",
+              "chmod +x set-env.sh\n",
+              "./set-env.sh\n",
 
               "aws s3 cp s3://gu-membership-attribute-service-dist/membership-attribute-service-bootstrap.sh .\n",
               "chmod +x membership-attribute-service-bootstrap.sh\n",
               "./membership-attribute-service-bootstrap.sh\n",
 
+              "aws s3 cp s3://gu-membership-attribute-service-dist/set-ssh-keys.sh .\n",
+              "chmod +x set-ssh-keys.sh\n",
+              "./set-ssh-keys.sh\n",
 
               "service membership-attribute-service start\n",
               "sleep 20s\n"

--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -1,13 +1,14 @@
 package configuration
 
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
-import com.github.dwhjames.awswrap.dynamodb.{AmazonDynamoDBScalaMapper, AmazonDynamoDBScalaClient}
-import com.gu.identity.cookie.{ProductionKeys, PreProductionKeys}
+import com.github.dwhjames.awswrap.dynamodb.{AmazonDynamoDBScalaClient, AmazonDynamoDBScalaMapper}
+import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
 import com.typesafe.config.ConfigFactory
 import play.api.Logger
+
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object Config {
@@ -22,7 +23,8 @@ object Config {
   val dynamoTable = config.getString("dynamodb.table")
 
   lazy val dynamoMapper = {
-    val awsCredentialsProvider = new AWSCredentialsProviderChain(new ProfileCredentialsProvider("identity"), new InstanceProfileCredentialsProvider())
+    val awsProfile = config.getString("aws-profile")
+    val awsCredentialsProvider = new AWSCredentialsProviderChain(new ProfileCredentialsProvider(awsProfile), new InstanceProfileCredentialsProvider())
 
     val awsDynamoClient = new AmazonDynamoDBAsyncClient(awsCredentialsProvider.getCredentials)
     awsDynamoClient.configureRegion(Regions.EU_WEST_1)

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -1,14 +1,14 @@
 package controllers
 
-import actions.CommonActions
-import models.{MembershipAttributes, ApiResponse}
-import play.api.mvc.BodyParsers
-import services.AttributeService
 import javax.inject._
+
+import actions.CommonActions
+import models.ApiResponse
+import services.AttributeService
+
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class AttributeController @Inject() (attributeService: AttributeService) extends CommonActions {
-
   def getMyAttributes = AuthenticatedAction.async { implicit request =>
     ApiResponse{
       attributeService.getAttributes(request.user.id)
@@ -19,19 +19,6 @@ class AttributeController @Inject() (attributeService: AttributeService) extends
     // TODO use access token to authenticate
     ApiResponse{
       attributeService.getAttributes(userId)
-    }
-  }
-
-  def setMyAttributes = AuthenticatedAction.async[MembershipAttributes](BodyParsers.parse.json[MembershipAttributes]) { implicit request =>
-    ApiResponse {
-      attributeService.setAttributes(request.user.id, request.body)
-    }
-  }
-
-  def setAttributes(userId: String) = NoCacheAction.async[MembershipAttributes](BodyParsers.parse.json[MembershipAttributes]) { implicit request =>
-    // TODO use access token to authenticate
-    ApiResponse {
-      attributeService.setAttributes(userId, request.body)
     }
   }
 }

--- a/membership-attribute-service/app/repositories/MembershipAttributesDynamo.scala
+++ b/membership-attribute-service/app/repositories/MembershipAttributesDynamo.scala
@@ -19,9 +19,9 @@ object MembershipAttributesDynamo {
   val tableName = Config.dynamoTable
 
   object Attributes {
-    val userId     = "UserId"
+    val userId = "UserId"
     val membershipNumber = "MembershipNumber"
-    val tier  = "Tier"
+    val tier = "Tier"
     val joinDate = "JoinDate"
   }
 
@@ -36,17 +36,17 @@ object MembershipAttributesDynamo {
 
     override def toAttributeMap(membershipAttributes: MembershipAttributesDynamo) =
       Map(
-        mkAttribute(Attributes.userId     -> membershipAttributes.userId),
+        mkAttribute(Attributes.userId -> membershipAttributes.userId),
         mkAttribute(Attributes.membershipNumber -> membershipAttributes.membershipNumber),
-        mkAttribute(Attributes.tier  -> membershipAttributes.tier),
+        mkAttribute(Attributes.tier -> membershipAttributes.tier),
         mkAttribute(Attributes.joinDate -> membershipAttributes.joinDate.toString)
       )
 
     override def fromAttributeMap(item: collection.mutable.Map[String, AttributeValue]) =
       MembershipAttributesDynamo(
-        userId     = item(Attributes.userId),
+        userId = item(Attributes.userId),
         membershipNumber = item(Attributes.membershipNumber),
-        tier  = item(Attributes.tier),
+        tier = item(Attributes.tier),
         joinDate = LocalDate.parse(item(Attributes.joinDate))
       )
   }

--- a/membership-attribute-service/conf/CODE.conf
+++ b/membership-attribute-service/conf/CODE.conf
@@ -1,3 +1,0 @@
-include "application.conf"
-
-stage=CODE

--- a/membership-attribute-service/conf/DEV.conf
+++ b/membership-attribute-service/conf/DEV.conf
@@ -1,3 +1,5 @@
 include "application.conf"
 
 stage=DEV
+dynamodb.table=MembershipAttributes-DEV
+aws-profile=membership

--- a/membership-attribute-service/conf/application.conf
+++ b/membership-attribute-service/conf/application.conf
@@ -1,5 +1,6 @@
 identity.production.keys=false
-dynamodb.table=MembershipAttributes-CODE
+dynamodb.table=MembershipAttributes-DEV
+aws-profile=membership
 
 #### Play Configuration
 

--- a/membership-attribute-service/conf/deploy.json
+++ b/membership-attribute-service/conf/deploy.json
@@ -1,5 +1,5 @@
 {
-  "defaultStacks": ["identity"],
+  "defaultStacks": ["membership"],
   "packages":{
     "membership-attribute-service":{
       "type":"autoscaling",

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -5,5 +5,3 @@ GET         /healthcheck                                @controllers.HealthCheck
 
 GET         /user-attributes/me/membership              @controllers.AttributeController.getMyAttributes
 GET         /user-attributes/:userId/membership         @controllers.AttributeController.getAttributes(userId)
-PUT         /user-attributes/me/membership              @controllers.AttributeController.setMyAttributes
-PUT         /user-attributes/:userId/membership         @controllers.AttributeController.setAttributes(userId)

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -6,16 +6,16 @@ import models.{ApiResponse, MembershipAttributes}
 import org.joda.time.LocalDate
 import org.mockito.Mockito._
 import org.specs2.mutable.Specification
-import play.api.libs.iteratee.{Iteratee, Input}
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.iteratee.{Input, Iteratee}
+import play.api.libs.json.JsValue
 import play.api.mvc.Security.AuthenticatedBuilder
 import play.api.mvc._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.AttributeService
 
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class AttributeControllerTest extends Specification {
 
@@ -56,19 +56,6 @@ class AttributeControllerTest extends Specification {
     }
   }
 
-  "setAttributes" should {
-    "update attributes for the given user id" in {
-      val attributes = MembershipAttributes(LocalDate.now, "patron", "abc")
-      val apiResponse = ApiResponse.Right(attributes)
-      val attributesJson = Json.toJson(attributes)
-      when(attributeService.setAttributes(userId, attributes)).thenReturn(apiResponse)
-
-      val req = addJsonBodyToRequest(FakeRequest(), attributesJson)
-      val result = executeJsonRequest(controller.setAttributes(userId)(req), attributesJson)
-      verifySuccessfulResult(result)
-    }
-  }
-
   "getMyAttributes" should {
     "return unauthorised when cookies not provided" in {
       val result = controller.getMyAttributes(FakeRequest())
@@ -84,30 +71,6 @@ class AttributeControllerTest extends Specification {
 
       val req = FakeRequest().withHeaders("Cookie" -> s"GU_U=$guCookie;SC_GU_U=$scGuCookie")
       val result = controller.getMyAttributes(req)
-      verifySuccessfulResult(result)
-    }
-  }
-
-  "setMyAttributes" should {
-    val attributes = MembershipAttributes(LocalDate.now, "patron", "abc")
-    val attributesJson = Json.toJson(attributes)
-
-    "return unauthorised when cookies not provided" in {
-      val req = addJsonBodyToRequest(FakeRequest(), attributesJson)
-      val result = executeJsonRequest(controller.setMyAttributes(req), attributesJson)
-      status(result) shouldEqual UNAUTHORIZED
-    }
-
-    "set attributes for user in cookie" in {
-      val apiResponse = ApiResponse.Right(MembershipAttributes(LocalDate.now, "patron", "abc"))
-      when(attributeService.setAttributes(userId, attributes)).thenReturn(apiResponse)
-
-      val guCookie = "gu_cookie"
-      val scGuCookie = "sc_gu_cookie"
-
-      val req = addJsonBodyToRequest(FakeRequest().withHeaders("Cookie" -> s"GU_U=$guCookie;SC_GU_U=$scGuCookie"), attributesJson)
-
-      val result = executeJsonRequest(controller.setMyAttributes(req), attributesJson)
       verifySuccessfulResult(result)
     }
   }

--- a/membership-attribute-service/test/repositories/MembershipAttributesRepositoryTest.scala
+++ b/membership-attribute-service/test/repositories/MembershipAttributesRepositoryTest.scala
@@ -53,7 +53,6 @@ class MembershipAttributesRepositoryTest extends Specification {
     }
 
     "retrieve not found api error when attributes not found for user" in {
-      val attributes = MembershipAttributes(LocalDate.parse("2015-07-28"), "patron", "abc")
       val result = for {
         retrieved <- repo.getAttributes(UUID.randomUUID().toString)
       } yield retrieved

--- a/project/MembershipAttributeService.scala
+++ b/project/MembershipAttributeService.scala
@@ -62,7 +62,7 @@ object MembershipAttributeService extends Build with MembershipAttributeService 
   val api = app("membership-attribute-service")
                 .settings(libraryDependencies ++= apiDependencies)
                 .settings(routesGenerator := InjectedRoutesGenerator)
-                .settings(addCommandAlias("devrun", "run -Dconfig.resource=dev.conf 9100"): _*)
+                .settings(addCommandAlias("devrun", "run -Dconfig.resource=DEV.conf 9100"): _*)
 
   val root = Project("root", base=file(".")).aggregate(api)
 }

--- a/provisioning/deploy.json
+++ b/provisioning/deploy.json
@@ -1,5 +1,5 @@
 {
-  "defaultStacks": [ "identity" ],
+  "defaultStacks": [ "membership" ],
   "packages": {
     "gu-membership-attribute-service-dist": {
       "type": "aws-s3",

--- a/provisioning/gu-membership-attribute-service-dist/membership-attribute-service-bootstrap.sh
+++ b/provisioning/gu-membership-attribute-service-dist/membership-attribute-service-bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ev
 
 source set-env.sh
 

--- a/provisioning/gu-membership-attribute-service-dist/set-env.sh
+++ b/provisioning/gu-membership-attribute-service-dist/set-env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ev
 
 if [ ! -f facts.txt ]; then
 instanceid=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)

--- a/provisioning/gu-membership-attribute-service-dist/set-ssh-keys.sh
+++ b/provisioning/gu-membership-attribute-service-dist/set-ssh-keys.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ev
+
+aws s3 cp s3://membership-dist/membership/authorized_keys /home/ubuntu/aws_authorized_keys
+cat /home/ubuntu/aws_authorized_keys >> /home/ubuntu/.ssh/authorized_keys
+
+chown ubuntu:ubuntu "/home/ubuntu/.ssh/authorized_keys"
+chmod 400 "/home/ubuntu/.ssh/authorized_keys"

--- a/provisioning/provisioning.json
+++ b/provisioning/provisioning.json
@@ -1,0 +1,30 @@
+{
+    "variables": {
+        "aws_access_key": "{{env `AWS_ACCESS_KEY`}}",
+        "aws_secret_key": "{{env `AWS_SECRET_KEY`}}"
+    },
+    "builders": [{
+        "type": "amazon-ebs",
+        "access_key": "{{user `aws_access_key`}}",
+        "secret_key": "{{user `aws_secret_key`}}",
+        "region": "eu-west-1",
+        "source_ami": "ami-2d96f65a",
+        "instance_type": "t2.micro",
+        "ssh_username": "ubuntu",
+        "ami_name": "gu-membership-{{isotime \"2006-01-02 03-04\"}}"
+    }],
+    "provisioners": [{
+        "type": "shell",
+        "inline": [
+            "sleep 20",
+            "sudo add-apt-repository -y ppa:webupd8team/java",
+            "sudo apt-get -y update",
+            "echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections",
+            "sudo apt-get -y install language-pack-en oracle-java8-installer unzip python-pip",
+            "sudo apt-get -y upgrade",
+            "sudo apt-get install oracle-java8-set-default",
+            "sudo pip install virtualenv",
+            "sudo pip install awscli"
+        ]
+    }]
+}


### PR DESCRIPTION
This prepares the transfer from the Identity team to the Membership team

- Remove the upsert endpoint that we don't need
- Add the AMI creation recipe
- Adapt the CF template to conform to the Membership habits and to remove the dependencies on some Identity internal requirements.