### PR TITLE
Add possibility to use fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ To start the service use:
 
 The service will be starting on 9100 and use the MembershipAttributes-DEV DynamoDB table.
 
+## Using fixtures
+
+You can use pre-canned responses by launching the app like so:
+
+```
+    $ sbt
+    > project membership-attribute-service
+    > devrun -Duse-fixtures=true
+```
+
+You can edit the pre-canned response by altering the file `app/models/Fixtures.scala`
+
 ## Metrics and Logs
 
 There is a Membership Attributes Service radiator. This uses standard ELB and DynamoBB CloudWatch metrics for the CloudFormation stack in the chosen stage.

--- a/membership-attribute-service/app/actions/Functions.scala
+++ b/membership-attribute-service/app/actions/Functions.scala
@@ -27,7 +27,7 @@ object Functions extends Results {
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = block(request).map(f)
   }
 
-  private def unauthenticated(request: RequestHeader): Result = ApiErrors.unauthorized
+  private def unauthenticated(request: RequestHeader): Result = ApiErrors.cookiesRequired
 
   val authenticatedExceptionHandler = new ActionFunction[AuthRequest, AuthRequest] {
     override def invokeBlock[A](request: AuthRequest[A], block: (AuthRequest[A]) => Future[Result]): Future[Result] =

--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -21,6 +21,7 @@ object Config {
 
   val idKeys = if (config.getBoolean("identity.production.keys")) new ProductionKeys else new PreProductionKeys
   val dynamoTable = config.getString("dynamodb.table")
+  val useFixtures = config.getBoolean("use-fixtures")
 
   lazy val dynamoMapper = {
     val awsProfile = config.getString("aws-profile")
@@ -31,6 +32,4 @@ object Config {
     val dynamoClient    = new AmazonDynamoDBScalaClient(awsDynamoClient)
     AmazonDynamoDBScalaMapper(dynamoClient)
   }
-
-
 }

--- a/membership-attribute-service/app/models/ApiErrors.scala
+++ b/membership-attribute-service/app/models/ApiErrors.scala
@@ -8,24 +8,30 @@ object ApiErrors {
       statusCode = 400
     )
 
-  def notFound: ApiError =
+  val notFound: ApiError =
     ApiError(
       message = "Not found",
       details = "Not Found",
       statusCode = 404
     )
 
-  def internalError: ApiError =
+  val internalError: ApiError =
     ApiError(
       message = "Internal Server Error",
       details = "Internal Server Error",
       statusCode = 500
     )
 
-  def unauthorized: ApiError =
+  val cookiesRequired: ApiError =
     ApiError(
       message = "Unauthorised",
       details = "Valid GU_U and SC_GU_U cookies are required.",
       statusCode = 401
     )
+
+  val unauthorized = ApiError(
+    message = "Unauthorized",
+    details = "Failed to authenticate",
+    statusCode = 401
+  )
 }

--- a/membership-attribute-service/app/models/Fixtures.scala
+++ b/membership-attribute-service/app/models/Fixtures.scala
@@ -1,0 +1,9 @@
+package models
+
+object Fixtures {
+  val membershipAttributes = MembershipAttributes(
+    userId = "123",
+    tier = "Patron",
+    membershipNumber = "456"
+  )
+}

--- a/membership-attribute-service/conf/application.conf
+++ b/membership-attribute-service/conf/application.conf
@@ -1,6 +1,7 @@
 identity.production.keys=false
 dynamodb.table=MembershipAttributes-DEV
 aws-profile=membership
+use-fixtures=false
 
 #### Play Configuration
 

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -6,7 +6,7 @@ import models.MembershipAttributes
 import org.mockito.Mockito._
 import org.specs2.mutable.Specification
 import play.api.libs.iteratee.{Input, Iteratee}
-import play.api.libs.json.{Json, JsValue}
+import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.Security.AuthenticatedBuilder
 import play.api.mvc._
 import play.api.test.FakeRequest
@@ -14,8 +14,7 @@ import play.api.test.Helpers._
 import services.AttributeService
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration._
+import scala.concurrent.Future
 
 class AttributeControllerTest extends Specification {
 


### PR DESCRIPTION
Add a `use-fixtures` property.

In this mode, the response for the GET endpoint is pre-canned, and defined in `app/models/Fixtures.scala`