### PR TITLE
Avoid overriding existing rows in batch load

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ You can edit the pre-canned response by altering the file `app/models/Fixtures.s
 
 ## Loading initial dataset
 
+- Make sure that the outbound messages are pointing to your instance
+
+- Truncate your DB
+
 - Download a CSV report file from Salesforce containing the required fields. The header should be
 
 ```
@@ -78,6 +82,8 @@ You can edit the pre-canned response by altering the file `app/models/Fixtures.s
 - run `sbt -Dconfig.resource=[DEV|PROD].conf ";project membership-attribute-service ;batch-load <path/to/csvfile.csv>"`
 
 - Decrease the write throughput of you dynamoDB instance to 1
+
+- Check that no records have been altered during the time the command takes to run. It's easy to check via the Membership History object in Salesforce.
 
 ## Metrics and Logs
 

--- a/membership-attribute-service/app/BatchLoader.scala
+++ b/membership-attribute-service/app/BatchLoader.scala
@@ -7,6 +7,8 @@ import configuration.Config._
 import models.MembershipAttributes
 import org.slf4j.LoggerFactory
 import sources.SalesforceCSVExport
+import repositories.MembershipAttributesDynamo.membershipAttributesSerializer
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import scala.collection.JavaConverters._
 
@@ -35,7 +37,7 @@ object BatchLoader {
       sys.exit(1)
     })({ path =>
       val file = new File(path)
-      dynamoMapper.scan[MembershipAttributes](Map.empty).map { existing =>
+      dynamoMapper.scan[MembershipAttributes](Map.empty).onSuccess { case existing =>
         val existingIds = existing.map(_.userId).toSet
         val requests = SalesforceCSVExport
           .membersAttributes(file)


### PR DESCRIPTION
Make sure that the rows we import from the CSV during initial loading don't override whatever rows already exist in the DB.

The records in a fresh DB that is updated only by outbound messages are always fresher than the ones coming from the CSV file.

@dominickendrick @rtyley