### PR TITLE
Instantiate Dynamo client with a creds provider

### DIFF
--- a/membership-attribute-service/app/BatchLoader.scala
+++ b/membership-attribute-service/app/BatchLoader.scala
@@ -43,7 +43,7 @@ object BatchLoader {
           .membersAttributes(file)
           .filterNot { attrs => existingIds.contains(attrs.userId) }
           .map(writeRequest)
-        val loader = new SingleThreadedBatchWriter(dynamoTable, AWS.credentials)
+        val loader = new SingleThreadedBatchWriter(dynamoTable, AWS.credentialsProvider)
         loader.client.withRegion(Regions.EU_WEST_1)
         loader.run(requests)
       }

--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -27,11 +27,10 @@ object Config {
   object AWS {
     val profile = config.getString("aws-profile")
     val credentialsProvider = new AWSCredentialsProviderChain(new ProfileCredentialsProvider(profile), new InstanceProfileCredentialsProvider())
-    val credentials = credentialsProvider.getCredentials
   }
 
   lazy val dynamoMapper = {
-    val awsDynamoClient = new AmazonDynamoDBAsyncClient(AWS.credentials)
+    val awsDynamoClient = new AmazonDynamoDBAsyncClient(AWS.credentialsProvider)
     awsDynamoClient.configureRegion(Regions.EU_WEST_1)
     val dynamoClient = new AmazonDynamoDBScalaClient(awsDynamoClient)
     AmazonDynamoDBScalaMapper(dynamoClient)


### PR DESCRIPTION
We currently instantiate the Dynamo client with credentials, which eventually expire. This uses a credentials provider instead, which is in charge of refreshing the creds.