### PR TITLE
delete entries that no longer belong to members

### DIFF
--- a/cloudformation/membership-attribute-service.json
+++ b/cloudformation/membership-attribute-service.json
@@ -156,6 +156,15 @@
               },
               {
                 "Effect": "Allow",
+                "Action": "dynamodb:DeleteItem",
+                "Resource": {
+                  "Fn::FindInMap": ["StageVariables", {
+                    "Ref": "Stage"
+                  }, "DynamoDBTable"]
+                }
+              },
+              {
+                "Effect": "Allow",
                 "Action": [
                   "cloudwatch:*",
                   "logs:*"

--- a/membership-attribute-service/app/repositories/MembershipAttributesRepository.scala
+++ b/membership-attribute-service/app/repositories/MembershipAttributesRepository.scala
@@ -18,8 +18,13 @@ class MembershipAttributesRepository @Inject() (dynamo: AmazonDynamoDBScalaMappe
     dynamo.loadByKey[MembershipAttributes](userId)
   }
 
-  def updateAttributes(attributes: MembershipAttributes): Future[Unit] = {
-    logger.debug(s"Update attributes: $attributes")
-    dynamo.dump(attributes)
-  }
+  def updateAttributes(attributes: MembershipAttributes): Future[Unit] =
+    if (attributes.tier.isEmpty) {
+      logger.debug(s"Delete attributes: $attributes")
+      dynamo.delete(attributes)
+    }
+    else {
+      logger.debug(s"Update attributes: $attributes")
+      dynamo.dump(attributes)
+    }
 }


### PR DESCRIPTION
Upon membership cancellation, user data should be deleted from members attributes service.