### PR TITLE
Add adfree endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,9 @@ Follow these [nginx setup](doc/nginx-setup.md) instructions
 
 ## Endpoints
 
-Access to endpoint for a specified id will be protected using an access token (TBD). They are currently not protected at all.
+For access to the /me endpoints, valid GU_U and SC_GU_U must be provided in the Cookie request header.
 
-For access to the /me endpoints, valid GU_U and SC_GU_U must be provided in the Cookie request header. 
-
-### Read enpoints
-
-    GET /user-attributes/me/membership
- 
-A Content-Type of "application/json" must be provided.
-
-### Responses
-
-All responses will have a JSON body.
+### GET /user-attributes/me/membership
 
 Success responses:
 
@@ -35,8 +25,16 @@ Error responses:
       "message": "Bad Request",
       "details": "Detailed error message"
     }
-    
-    
+
+### GET /user-attributes/me/adfree
+Responses:
+
+    {
+      "adfree": "true",
+    }
+
+This also drops an unsigned `gu_adfree_user` cookie.
+
 ## Running Locally
 
 Ensure that your ~/.aws/credentials file contains the following:

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -7,10 +7,16 @@ import configuration.Config
 import models.ApiErrors.unauthorized
 import models.Fixtures
 import play.api.libs.concurrent.Execution.Implicits._
-import play.api.mvc.Action
-import services.AttributeService
+import play.api.libs.json.Json
+import play.api.mvc.Results.Ok
+import play.api.mvc.{Action, Cookie}
+import services.{AttributeService, AuthenticationService}
+
+import scala.concurrent.Future
 
 class AttributeController @Inject() (attributeService: AttributeService) extends CommonActions {
+  val ADFREE_COOKIE_MAX_AGE = 60 * 60 * 6 // 6 hours
+
   def getMyAttributes =
     if (Config.useFixtures)
       getMyAttributesFromFixtures
@@ -28,4 +34,19 @@ class AttributeController @Inject() (attributeService: AttributeService) extends
   private def getMyAttributesFromFixtures = Action {
     Fixtures.membershipAttributes
   }
+
+  private def adfreeResponse(adfree: Boolean) =
+    Ok(Json.obj("adfree" -> adfree))
+      .withCookies(Cookie("gu_adfree_user", adfree.toString, maxAge = Some(ADFREE_COOKIE_MAX_AGE)))
+
+  def adFree =
+    Action.async { implicit request =>
+      AuthenticationService.authenticatedUserFor(request)
+        .fold(Future(adfreeResponse(false))){ minUser =>
+          attributeService.getAttributes(minUser.id).map { attrs =>
+            val isFreeTier = attrs.exists(_.tier.equalsIgnoreCase("friend"))
+            adfreeResponse(!isFreeTier)
+          }
+        }
+    }
 }

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -3,4 +3,5 @@
 GET        /healthcheck                          @controllers.HealthCheckController.healthCheck
 
 GET        /user-attributes/me/membership        @controllers.AttributeController.getMyAttributes
+GET        /user-attributes/me/adfree            @controllers.AttributeController.adFree
 POST       /salesforce-hook                      @controllers.SalesforceHookController.createAttributes


### PR DESCRIPTION
Add an adfree enpoint at `GET /user-attributes/me/adfree` that returns a boolean result and drops a `gu_adfree_user` cookie