### PR TITLE
return 404 if user is not found in db

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -4,7 +4,7 @@ import javax.inject._
 
 import actions.CommonActions
 import configuration.Config
-import models.ApiErrors.unauthorized
+import models.ApiErrors.notFound
 import models.Fixtures
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
@@ -27,7 +27,7 @@ class AttributeController @Inject() (attributeService: AttributeService) extends
     AuthenticatedAction.async { implicit request =>
       attributeService.getAttributes(request.user.id).map {
         case Some(attrs) => attrs
-        case None => unauthorized
+        case None => notFound
       }
     }
 


### PR DESCRIPTION
At the moment we return Unauthorised code, even though the authentication cookie is present and valid.