### PR TITLE
Handle empty membership number

### DIFF
--- a/membership-attribute-service/app/BatchLoader.scala
+++ b/membership-attribute-service/app/BatchLoader.scala
@@ -23,7 +23,7 @@ object BatchLoader {
             Map(
               "UserId" -> attrs.userId,
               "Tier" -> attrs.tier,
-              "MembershipNumber" -> attrs.membershipNumber
+              "MembershipNumber" -> attrs.membershipNumber.getOrElse("")
             ).mapValues(new AttributeValue(_)).asJava
           )
       )

--- a/membership-attribute-service/app/models/Fixtures.scala
+++ b/membership-attribute-service/app/models/Fixtures.scala
@@ -4,6 +4,6 @@ object Fixtures {
   val membershipAttributes = MembershipAttributes(
     userId = "123",
     tier = "Patron",
-    membershipNumber = "456"
+    membershipNumber = Some("456")
   )
 }

--- a/membership-attribute-service/app/models/MembershipAttributes.scala
+++ b/membership-attribute-service/app/models/MembershipAttributes.scala
@@ -6,9 +6,8 @@ import play.api.mvc.Results.Ok
 
 import scala.language.implicitConversions
 
-case class MembershipAttributes(userId: String, tier: String, membershipNumber: String) {
-  require(tier.nonEmpty)
-
+case class MembershipAttributes(userId: String, tier: String, membershipNumber: Option[String]) {
+  require(tier.nonEmpty && userId.nonEmpty)
   lazy val isFriendTier = tier.equalsIgnoreCase("friend")
   lazy val isPaidTier = !isFriendTier
 }

--- a/membership-attribute-service/app/parsers/Salesforce.scala
+++ b/membership-attribute-service/app/parsers/Salesforce.scala
@@ -21,6 +21,7 @@ object Salesforce {
       id <- obj.getText("IdentityID__c")
       tier <- obj.getText("Membership_Tier__c")
       num <- obj.getText("Membership_Number__c")
-    } yield MembershipAttributes(id, tier, num)
+      numOpt = if (num.isEmpty) None else Some(num)
+    } yield MembershipAttributes(id, tier, numOpt)
   }
 }

--- a/membership-attribute-service/app/repositories/MembershipAttributesDynamo.scala
+++ b/membership-attribute-service/app/repositories/MembershipAttributesDynamo.scala
@@ -25,16 +25,18 @@ object MembershipAttributesDynamo {
     override def toAttributeMap(membershipAttributes: MembershipAttributes) =
       Map(
         mkAttribute(Attributes.userId -> membershipAttributes.userId),
-        mkAttribute(Attributes.membershipNumber -> membershipAttributes.membershipNumber),
+        mkAttribute(Attributes.membershipNumber -> membershipAttributes.membershipNumber.getOrElse("")),
         mkAttribute(Attributes.tier -> membershipAttributes.tier)
       )
 
-    override def fromAttributeMap(item: collection.mutable.Map[String, AttributeValue]) =
+    override def fromAttributeMap(item: collection.mutable.Map[String, AttributeValue]) = {
+      val numOpt = if (Attributes.membershipNumber.isEmpty) None else Some(Attributes.membershipNumber)
+
       MembershipAttributes(
         userId = item(Attributes.userId),
-        membershipNumber = item(Attributes.membershipNumber),
+        membershipNumber = numOpt.map(item.apply),
         tier = item(Attributes.tier)
       )
+    }
   }
-
 }

--- a/membership-attribute-service/app/sources/SalesforceCSVExport.scala
+++ b/membership-attribute-service/app/sources/SalesforceCSVExport.scala
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory
 import scala.io.Source
 
 object SalesforceCSVExport {
-  private val re = """"(\w+)","(\w+)","(\w+)","(.+)"""".r
+  private val re = """"(\w+)","(\w*)","(\w+)","(.+)"""".r
   private val logger = LoggerFactory.getLogger(getClass)
 
   def membersAttributes(file: File): Iterator[MembershipAttributes] = {
@@ -16,7 +16,8 @@ object SalesforceCSVExport {
       .getLines().drop(1) // The export file comes with CSV headers
       .map {
         case re(id, num, tier, date) =>
-          Some(MembershipAttributes(id, tier, num))
+          val numOpt = if (num.isEmpty) None else Some(num)
+          Some(MembershipAttributes(id, tier, numOpt))
         case str =>
           logger.error(s"Couldn't parse line\n$str\nas a valid members attribute")
           None

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -56,7 +56,7 @@ class AttributeControllerTest extends Specification {
     }
 
     "retrieve attributes for user in cookie" in {
-      val apiResponse = Future { Some(MembershipAttributes("123", "patron", "abc")) }
+      val apiResponse = Future { Some(MembershipAttributes("123", "patron", Some("abc"))) }
       when(attributeService.getAttributes(userId)).thenReturn(apiResponse)
 
       val guCookie = "gu_cookie"

--- a/membership-attribute-service/test/parsers/SalesforceTest.scala
+++ b/membership-attribute-service/test/parsers/SalesforceTest.scala
@@ -29,7 +29,7 @@ class SalesforceTest extends Specification {
           </soapenv:Body>
         </soapenv:Envelope>
 
-      Salesforce.parseOutboundMessage(payload) shouldEqual MembershipAttributes("identity_id", "Supporter", "membership_number").right
+      Salesforce.parseOutboundMessage(payload) shouldEqual MembershipAttributes("identity_id", "Supporter", Some("membership_number")).right
     }
   }
 }

--- a/membership-attribute-service/test/repositories/MembershipAttributesRepositoryTest.scala
+++ b/membership-attribute-service/test/repositories/MembershipAttributesRepositoryTest.scala
@@ -42,7 +42,7 @@ class MembershipAttributesRepositoryTest extends Specification {
   "getAttributes" should {
     "retrieve attributes for given user" in {
       val userId = UUID.randomUUID().toString
-      val attributes = MembershipAttributes(userId, "patron", "abc")
+      val attributes = MembershipAttributes(userId, "patron", Some("abc"))
       val result = for {
         insertResult <- repo.updateAttributes(attributes)
         retrieved <- repo.getAttributes(userId)

--- a/membership-attribute-service/test/resources/contacts.csv
+++ b/membership-attribute-service/test/resources/contacts.csv
@@ -1,3 +1,4 @@
 "IdentityID","Membership Number","Membership Tier","Last Modified Date"
 "323479263","292451","Partner","19/03/2015"
 "323479267","292454","Patron","19/03/2015"
+"323479268","","Friend","19/03/2015"

--- a/membership-attribute-service/test/sources/SalesforceCSVExportSpec.scala
+++ b/membership-attribute-service/test/sources/SalesforceCSVExportSpec.scala
@@ -16,8 +16,9 @@ class SalesforceCSVExportSpec extends Specification {
         val attributes = SalesforceCSVExport.membersAttributes(file).toList
 
         attributes shouldEqual List(
-          MembershipAttributes("323479263", "Partner", "292451"),
-          MembershipAttributes("323479267", "Patron", "292454")
+          MembershipAttributes("323479263", "Partner", Some("292451")),
+          MembershipAttributes("323479267", "Patron", Some("292454")),
+          MembershipAttributes("323479268", "Friend", None)
         )
       }
     }


### PR DESCRIPTION
Some member (including all friends) have an empty membership number, which cause their import to fail. This allow for an empty membership number