### PR TITLE
work around AWS client constraints for empty fields

### DIFF
--- a/membership-attribute-service/app/repositories/MembershipAttributesDynamo.scala
+++ b/membership-attribute-service/app/repositories/MembershipAttributesDynamo.scala
@@ -24,10 +24,10 @@ object MembershipAttributesDynamo {
 
     override def toAttributeMap(membershipAttributes: MembershipAttributes) =
       Map(
-        mkAttribute(Attributes.userId -> membershipAttributes.userId),
-        mkAttribute(Attributes.membershipNumber -> membershipAttributes.membershipNumber.getOrElse("")),
-        mkAttribute(Attributes.tier -> membershipAttributes.tier)
-      )
+        Attributes.userId -> membershipAttributes.userId,
+        Attributes.membershipNumber -> membershipAttributes.membershipNumber.getOrElse(""),
+        Attributes.tier -> membershipAttributes.tier
+      ).filter(_._2.nonEmpty).map(mkAttribute[String])
 
     override def fromAttributeMap(item: collection.mutable.Map[String, AttributeValue]) = {
       val numOpt = if (Attributes.membershipNumber.isEmpty) None else Some(Attributes.membershipNumber)


### PR DESCRIPTION
AWS Dynamo DB client does not allow empty values to be set