### PR TITLE
Only accept outbound messages with the right organization Id

### DIFF
--- a/membership-attribute-service/app/actions/SalesforceAuthAction.scala
+++ b/membership-attribute-service/app/actions/SalesforceAuthAction.scala
@@ -12,7 +12,7 @@ object SalesforceAuthAction extends ActionBuilder[Request] {
   private val salesforceSecretParam = "secret"
 
   override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] = {
-    val secretMatches = request.getQueryString(salesforceSecretParam).contains(Config.salesforceSecret)
+    val secretMatches = request.getQueryString(salesforceSecretParam).contains(Config.Salesforce.secret)
 
     if (secretMatches) {
       block(request)

--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -24,7 +24,10 @@ object Config {
   val useFixtures = config.getBoolean("use-fixtures")
   lazy val sentryDsn = Try(new Dsn(config.getString("sentry.dsn")))
 
-  val salesforceSecret = config.getString("salesforce.hook-secret")
+  object Salesforce {
+    val secret = config.getString("salesforce.hook-secret")
+    val organizationId = config.getString("salesforce.organization-id")
+  }
 
   object AWS {
     val profile = config.getString("aws-profile")

--- a/membership-attribute-service/app/controllers/SalesforceHookController.scala
+++ b/membership-attribute-service/app/controllers/SalesforceHookController.scala
@@ -1,8 +1,10 @@
 package controllers
 
 import actions.SalesforceAuthAction
+import configuration.Config
 import models.ApiErrors
 import monitoring.CloudWatch
+import parsers.Salesforce.{OrgIdMatchingError, ParsingError}
 import parsers.{Salesforce => SFParser}
 import play.Logger
 import play.api.libs.concurrent.Execution.Implicits._
@@ -18,16 +20,19 @@ class SalesforceHookController {
   lazy val attributeService: AttributeService = DynamoAttributeService()
   val metrics = CloudWatch("SalesforceHookController")
   def createAttributes = SalesforceAuthAction.async(parse.xml) { request =>
-    SFParser.parseOutboundMessage(request.body) match {
+    SFParser.parseOutboundMessage(request.body, Config.Salesforce.organizationId) match {
       case \/-(attrs) if attrs.tier.isEmpty =>
         metrics.put("Delete", 1)
         attributeService.delete(attrs.userId).map(const(Ok))
       case \/-(attrs) =>
         metrics.put("Update", 1)
         attributeService.set(attrs).map(const(attrs))
-      case -\/(msg) =>
-        Logger.error(s"Web hook payload unrecognised ${request.body}")
+      case -\/(ParsingError(msg)) =>
+        Logger.error(s"Could not parse payload ${request.body}")
         Future { ApiErrors.badRequest(msg) }
+      case -\/(OrgIdMatchingError(orgId)) =>
+        Logger.error(s"Wrong organization Id: $orgId")
+        Future { ApiErrors.unauthorized.copy("Wrong organization Id") }
     }
   }
 }

--- a/membership-attribute-service/conf/DEV.conf
+++ b/membership-attribute-service/conf/DEV.conf
@@ -4,4 +4,7 @@ stage=DEV
 dynamodb.table=MembershipAttributes-DEV
 aws-profile=membership
 
-salesforce.hook-secret="secret-key"
+salesforce {
+  hook-secret = "secret-key"
+  organization-id = "orgId"
+}

--- a/membership-attribute-service/conf/application.conf
+++ b/membership-attribute-service/conf/application.conf
@@ -4,6 +4,7 @@ aws-profile=membership
 use-fixtures=false
 
 salesforce.hook-secret=null
+salesforce.organizationId=null
 
 #### Play Configuration
 

--- a/membership-attribute-service/test/actions/SalesforceAuthActionTest.scala
+++ b/membership-attribute-service/test/actions/SalesforceAuthActionTest.scala
@@ -15,7 +15,7 @@ class SalesforceAuthActionTest extends Specification {
     }
 
     "let through a request with the Salesforce shared secret in the query string" in {
-      val result = call(action, fakeRequest(Some(Config.salesforceSecret)))
+      val result = call(action, fakeRequest(Some(Config.Salesforce.secret)))
       status(result) mustEqual OK
     }
 

--- a/membership-attribute-service/test/parsers/SalesforceTest.scala
+++ b/membership-attribute-service/test/parsers/SalesforceTest.scala
@@ -2,16 +2,18 @@ package parsers
 
 import models.MembershipAttributes
 import org.specs2.mutable.Specification
+import parsers.Salesforce.OrgIdMatchingError
 import scalaz.syntax.either._
 
 class SalesforceTest extends Specification {
+  val orgId = "organizationId"
   "parseOutboundMessage" should {
     "deserialize a valid Salesforce Outbound Message with MembershipNumber" in {
       val payload =
         <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
           <soapenv:Body>
             <notifications xmlns="http://soap.sforce.com/2005/09/outbound">
-              <OrganizationId>org_id</OrganizationId>
+              <OrganizationId>{orgId}</OrganizationId>
               <ActionId>action_id</ActionId>
               <SessionId xsi:nil="true"/>
               <EnterpriseUrl>https://cs17.salesforce.com/services/Soap/c/34.0/enterprise_id</EnterpriseUrl>
@@ -29,7 +31,7 @@ class SalesforceTest extends Specification {
           </soapenv:Body>
         </soapenv:Envelope>
 
-      Salesforce.parseOutboundMessage(payload) shouldEqual MembershipAttributes("identity_id", "Supporter", Some("membership_number")).right
+      Salesforce.parseOutboundMessage(payload, orgId) shouldEqual MembershipAttributes("identity_id", "Supporter", Some("membership_number")).right
     }
 
     "deserialize a valid Salesforce Outbound Message without MembershipNumber" in {
@@ -37,7 +39,7 @@ class SalesforceTest extends Specification {
         <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
           <soapenv:Body>
             <notifications xmlns="http://soap.sforce.com/2005/09/outbound">
-              <OrganizationId>org_id</OrganizationId>
+              <OrganizationId>{orgId}</OrganizationId>
               <ActionId>action_id</ActionId>
               <SessionId xsi:nil="true"/>
               <EnterpriseUrl>https://cs17.salesforce.com/services/Soap/c/34.0/enterprise_id</EnterpriseUrl>
@@ -54,7 +56,32 @@ class SalesforceTest extends Specification {
           </soapenv:Body>
         </soapenv:Envelope>
 
-      Salesforce.parseOutboundMessage(payload) shouldEqual MembershipAttributes("identity_id", "Supporter", None).right
+      Salesforce.parseOutboundMessage(payload, orgId) shouldEqual MembershipAttributes("identity_id", "Supporter", None).right
+    }
+
+    "returns an error if the organization does not match the expected one" in {
+      val payload =
+        <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <soapenv:Body>
+            <notifications xmlns="http://soap.sforce.com/2005/09/outbound">
+              <OrganizationId>wrong org</OrganizationId>
+              <ActionId>action_id</ActionId>
+              <SessionId xsi:nil="true"/>
+              <EnterpriseUrl>https://cs17.salesforce.com/services/Soap/c/34.0/enterprise_id</EnterpriseUrl>
+              <PartnerUrl>https://cs17.salesforce.com/services/Soap/u/34.0/enterprise_id</PartnerUrl>
+              <Notification>
+                <Id>notification_id</Id>
+                <sObject xsi:type="sf:Contact" xmlns:sf="urn:sobject.enterprise.soap.sforce.com">
+                  <sf:Id>id</sf:Id>
+                  <sf:IdentityID__c>identity_id</sf:IdentityID__c>
+                  <sf:Membership_Tier__c>Supporter</sf:Membership_Tier__c>
+                </sObject>
+              </Notification>
+            </notifications>
+          </soapenv:Body>
+        </soapenv:Envelope>
+
+      Salesforce.parseOutboundMessage(payload, orgId) shouldEqual OrgIdMatchingError("wrong org").left
     }
   }
 }


### PR DESCRIPTION
Waiting for the PROD organization id

This PR only accepts outbound messages with the right organization Id.
[Trello ticket](https://trello.com/c/ZGOXNxSo/168-member-data-api-filter-outbound-messages-by-organization-id)

The prod config file has been changed accordingly

@rtyley @dominickendrick 