### PR TITLE
Add a gu_adblock_message cookie

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -29,7 +29,10 @@ class AttributeController {
 
   private def adfreeResponse(adfree: Boolean) =
     Ok(Json.obj("adfree" -> adfree, "issuedAt" -> scala.compat.Platform.currentTime))
-      .withCookies(Cookie("gu_adfree_user", adfree.toString, maxAge = Some(ADFREE_COOKIE_MAX_AGE)))
+      .withCookies(
+        Cookie("gu_adfree_user", adfree.toString, maxAge = Some(ADFREE_COOKIE_MAX_AGE)),
+        Cookie("gu_adblock_message", adfree.toString, maxAge = Some(ADFREE_COOKIE_MAX_AGE))
+      )
 
   def adFree = backendAction.async { implicit request =>
     authenticationService.userId


### PR DESCRIPTION
Add a cookie that drives the ad banner for membership, as per [the Trello ticket](https://trello.com/c/STuEhVmU/181-add-a-cookie-for-membership-banner) that come from a requirement from the commercial team

SUBJECT TO DEBATE

@davidrapson @rtyley 