### PR TITLE
Add CORS

### DIFF
--- a/membership-attribute-service/app/Global.scala
+++ b/membership-attribute-service/app/Global.scala
@@ -3,11 +3,13 @@ import models.ApiErrors._
 import play.api.Logger
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.{RequestHeader, Result, WithFilters}
+import play.filters.cors.CORSFilter
 import play.filters.csrf._
+import configuration.Config.corsConfig
 
 import scala.concurrent.Future
 
-object Global extends WithFilters(CSRFFilter(), AddEC2InstanceHeader, LogRequestsFilter) {
+object Global extends WithFilters(CSRFFilter(), AddEC2InstanceHeader, LogRequestsFilter, CORSFilter(corsConfig)) {
 
   private val logger = Logger(this.getClass)
 

--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -10,6 +10,8 @@ import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
 import com.gu.identity.testing.usernames.{Encoder, TestUsernames}
 import com.typesafe.config.ConfigFactory
 import net.kencochrane.raven.dsn.Dsn
+import play.api.Configuration
+import play.filters.cors.CORSConfig
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Try
@@ -59,4 +61,6 @@ object Config {
   }
 
   lazy val testUsernames = TestUsernames(Encoder.withSecret(config.getString("identity.test.users.secret")), 2.days.toStandardDuration)
+
+  val corsConfig = CORSConfig.fromConfiguration(Configuration(config))
 }

--- a/membership-attribute-service/conf/PROD.conf
+++ b/membership-attribute-service/conf/PROD.conf
@@ -13,3 +13,12 @@ sentry.dsn="https://b4537d8d803a4f58b3d19daa71435544:7d2cbef1b828492aabe30ed494c
 
 touchpoint.backend.default=PROD
 touchpoint.backend.test=UAT
+
+play.filters.cors.allowedOrigins = [
+  "http://www.theguardian.com",
+  "https://www.theguardian.com",
+  "http://m.code.dev-theguardian.com",
+  "https://m.code.dev-theguardian.com",
+  "http://membership.theguardian.com",
+  "https://membership.theguardian.com"
+]

--- a/membership-attribute-service/conf/PROD.conf
+++ b/membership-attribute-service/conf/PROD.conf
@@ -20,7 +20,11 @@ play.filters.cors.allowedOrigins = [
   "http://m.code.dev-theguardian.com",
   "https://m.code.dev-theguardian.com",
   "https://membership.theguardian.com",
-  "https://profile.thegulocal.com",
   "https://profile.code.dev-theguardian.com",
-  "https://profile.theguardian.com"
+  "https://profile.theguardian.com",
+
+  "https://profile.thegulocal.com",
+  "https://membership.thegulocal.com",
+  "http://www.thegulocal.com",
+  "https://www.thegulocal.com"
 ]

--- a/membership-attribute-service/conf/PROD.conf
+++ b/membership-attribute-service/conf/PROD.conf
@@ -19,6 +19,5 @@ play.filters.cors.allowedOrigins = [
   "https://www.theguardian.com",
   "http://m.code.dev-theguardian.com",
   "https://m.code.dev-theguardian.com",
-  "http://membership.theguardian.com",
   "https://membership.theguardian.com"
 ]

--- a/membership-attribute-service/conf/PROD.conf
+++ b/membership-attribute-service/conf/PROD.conf
@@ -19,5 +19,8 @@ play.filters.cors.allowedOrigins = [
   "https://www.theguardian.com",
   "http://m.code.dev-theguardian.com",
   "https://m.code.dev-theguardian.com",
-  "https://membership.theguardian.com"
+  "https://membership.theguardian.com",
+  "https://profile.thegulocal.com",
+  "https://profile.code.dev-theguardian.com",
+  "https://profile.theguardian.com"
 ]


### PR DESCRIPTION
Add CORS headers for

- www.theguardian.com
- m.code.dev-theguardian.com
- membership.theguardian.com

@rtyley @kenlim @jbreckmckye @davidrapson : Do you think we covered all the cases for the time being?