### PR TITLE
Change the www.thegulocal to m.thegulocal in CORS

### DIFF
--- a/membership-attribute-service/conf/PROD.conf
+++ b/membership-attribute-service/conf/PROD.conf
@@ -25,6 +25,6 @@ play.filters.cors.allowedOrigins = [
 
   "https://profile.thegulocal.com",
   "https://membership.thegulocal.com",
-  "http://www.thegulocal.com",
-  "https://www.thegulocal.com"
+  "http://m.thegulocal.com",
+  "https://m.thegulocal.com"
 ]


### PR DESCRIPTION
This is to conform to the local domain that is chosen in the front end repo. See https://github.com/guardian/frontend/blob/master/nginx/frontend.conf

@rtyley 