### PR TITLE
Increase cookie max-age to 3 months

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -13,7 +13,7 @@ import services.{AuthenticationService, IdentityAuthService}
 import scala.concurrent.Future
 
 class AttributeController {
-  val ADFREE_COOKIE_MAX_AGE = 60 * 60 * 6 // 6 hours
+  val ADFREE_COOKIE_MAX_AGE = 60 * 60 * 24 // 1 day
   lazy val authenticationService: AuthenticationService = IdentityAuthService
   lazy val backendAction = BackendFromCookieAction
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -13,7 +13,7 @@ import services.{AuthenticationService, IdentityAuthService}
 import scala.concurrent.Future
 
 class AttributeController {
-  val ADFREE_COOKIE_MAX_AGE = 60 * 60 * 24 // 1 day
+  val ADFREE_COOKIE_MAX_AGE = 60 * 60 * 24 * 30 * 3 // about 3 months
   lazy val authenticationService: AuthenticationService = IdentityAuthService
   lazy val backendAction = BackendFromCookieAction
 


### PR DESCRIPTION
As per the commercial team recommendation

@jbreckmckye @rtyley 