### PR TITLE
Only provide adfree to commercial team members

### DIFF
--- a/membership-attribute-service/app/actions/WithBackendFromSalesforceAction.scala
+++ b/membership-attribute-service/app/actions/WithBackendFromSalesforceAction.scala
@@ -18,11 +18,10 @@ object WithBackendFromSalesforceAction extends ActionRefiner[Request, BackendReq
   override protected def refine[A](request: Request[A]): Future[Either[Result, BackendRequest[A]]] = {
     import BackendConfig._
     Future {
-      val backendConf = Seq(test, default).find(_.salesforceConfig.secret.some == request.getQueryString("secret"))
+      val backendConf = Seq(test, default).find(_.salesforceConfig.secret.some == request.getQueryString(salesforceSecretParam))
 
       backendConf.map { conf =>
         val attrService = DynamoAttributeService(MembershipAttributesSerializer(conf.dynamoTable))
-
         Right(new BackendRequest[A](conf, attrService, request))
       }.getOrElse {
         Logger.error("Unauthorized call from salesforce: the secret didn't match that of any backend")

--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -15,6 +15,7 @@ import play.filters.cors.CORSConfig
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Try
+import scala.collection.JavaConverters._
 
 object Config {
   val config = ConfigFactory.load()
@@ -68,4 +69,7 @@ object Config {
   lazy val testUsernames = TestUsernames(Encoder.withSecret(config.getString("identity.test.users.secret")), 2.days.toStandardDuration)
 
   val corsConfig = CORSConfig.fromConfiguration(Configuration(config))
+
+  // TODO: remove once the adfree feature is generally available to the public
+  val preReleaseUsersIds = config.getStringList("identity.prerelease-users").asScala.toSet
 }

--- a/membership-attribute-service/app/models/Features.scala
+++ b/membership-attribute-service/app/models/Features.scala
@@ -1,5 +1,6 @@
 package models
 
+import configuration.Config
 import play.api.libs.json.Json
 import play.api.mvc.Result
 import play.api.mvc.Results.Ok
@@ -12,11 +13,16 @@ object Features {
   implicit def toResult(attrs: Features): Result =
     Ok(Json.toJson(attrs))
 
-  def fromAttributes(attributes: Attributes) = Features(
-    userId = Some(attributes.userId),
-    adFree = attributes.isPaidTier,
-    adblockMessage = !attributes.isPaidTier
-  )
+  def fromAttributes(attributes: Attributes) = {
+    // TODO: remove the second condition once the adfree feature is generally available to the public
+    val adfree = attributes.isPaidTier && Config.preReleaseUsersIds.contains(attributes.userId)
+
+    Features(
+      userId = Some(attributes.userId),
+      adFree = adfree,
+      adblockMessage = !adfree
+    )
+  }
 
   val unauthenticated = Features(None, adFree = false, adblockMessage = true)
 }

--- a/membership-attribute-service/conf/application.conf
+++ b/membership-attribute-service/conf/application.conf
@@ -17,4 +17,8 @@ logger.play=INFO
 # Logger provided to your application:
 logger.application=INFO
 
+# TODO: remove once the adfree feature is generally available to the public
+# These users are the only ones who can potentially get a positive adfree response until the system is deemed stable
+identity.prerelease-users = []
+
 include file("/etc/gu/members-data-api.conf")

--- a/membership-attribute-service/test/models/AttributesTest.scala
+++ b/membership-attribute-service/test/models/AttributesTest.scala
@@ -4,7 +4,7 @@ import org.specs2.mutable.Specification
 
 class AttributesTest extends Specification {
 
-  "MembershipAttributesTest" should {
+  "AttributesTest" should {
     val attrs = Attributes("123", "tier", None)
 
     "isPaidTier returns" should {


### PR DESCRIPTION
The commercial team want to test this feature with their own accounts only before they roll it out to the general public

@rtyley @kenlim @tomverran 

Note that this is not even smoke tested as the CODE Identity API is down ATM