### PR TITLE
Re-enable the "adfree" whitelist

### DIFF
--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -15,6 +15,7 @@ import play.filters.cors.CORSConfig
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Try
+import scala.collection.JavaConverters._
 
 object Config {
   val config = ConfigFactory.load()
@@ -68,4 +69,7 @@ object Config {
   lazy val testUsernames = TestUsernames(Encoder.withSecret(config.getString("identity.test.users.secret")), 2.days.toStandardDuration)
 
   val corsConfig = CORSConfig.fromConfiguration(Configuration(config))
+
+  // TODO: remove once the adfree feature is generally available to the public
+  val preReleaseUsersIds = config.getStringList("identity.prerelease-users").asScala.toSet
 }

--- a/membership-attribute-service/app/models/Features.scala
+++ b/membership-attribute-service/app/models/Features.scala
@@ -14,12 +14,12 @@ object Features {
     Ok(Json.toJson(attrs))
 
   def fromAttributes(attributes: Attributes) = {
-    // TODO: remove the second condition once the adfree feature is generally available to the public
-    val adfree = Config.preReleaseUsersIds.contains(attributes.userId)
-
+    // TODO: Change to a proper user preference evaluation once launched
+    val adfreeEnabled = Config.preReleaseUsersIds.contains(attributes.userId)
+    
     Features(
       userId = Some(attributes.userId),
-      adFree = adfree,
+      adFree = adfreeEnabled,
       adblockMessage = !(attributes.isPaidTier)
     )
   }

--- a/membership-attribute-service/app/models/Features.scala
+++ b/membership-attribute-service/app/models/Features.scala
@@ -1,5 +1,6 @@
 package models
 
+import configuration.Config
 import play.api.libs.json.Json
 import play.api.mvc.Result
 import play.api.mvc.Results.Ok
@@ -13,7 +14,8 @@ object Features {
     Ok(Json.toJson(attrs))
 
   def fromAttributes(attributes: Attributes) = {
-    val adfree = attributes.isPaidTier
+    // TODO: remove the second condition once the adfree feature is generally available to the public
+    val adfree = attributes.isPaidTier && Config.preReleaseUsersIds.contains(attributes.userId)
 
     Features(
       userId = Some(attributes.userId),

--- a/membership-attribute-service/app/models/Features.scala
+++ b/membership-attribute-service/app/models/Features.scala
@@ -14,8 +14,9 @@ object Features {
     Ok(Json.toJson(attrs))
 
   def fromAttributes(attributes: Attributes) = {
-    // TODO: Change to a proper user preference evaluation once launched
-    val adfreeEnabled = Config.preReleaseUsersIds.contains(attributes.userId)
+    // TODO: Once this officially launches, this should be:
+    // attributes.isPaidTier && (user has opted INTO the ad free experience)
+    val adfreeEnabled = attributes.isPaidTier && Config.preReleaseUsersIds.contains(attributes.userId)
     
     Features(
       userId = Some(attributes.userId),

--- a/membership-attribute-service/app/models/Features.scala
+++ b/membership-attribute-service/app/models/Features.scala
@@ -15,12 +15,12 @@ object Features {
 
   def fromAttributes(attributes: Attributes) = {
     // TODO: remove the second condition once the adfree feature is generally available to the public
-    val adfree = attributes.isPaidTier && Config.preReleaseUsersIds.contains(attributes.userId)
+    val adfree = Config.preReleaseUsersIds.contains(attributes.userId)
 
     Features(
       userId = Some(attributes.userId),
       adFree = adfree,
-      adblockMessage = !adfree
+      adblockMessage = !(attributes.isPaidTier)
     )
   }
 

--- a/membership-attribute-service/conf/application.conf
+++ b/membership-attribute-service/conf/application.conf
@@ -17,4 +17,8 @@ logger.play=INFO
 # Logger provided to your application:
 logger.application=INFO
 
+# TODO: remove once the adfree feature is generally available to the public
+# These users are the only ones who can potentially get a positive adfree response until the system is deemed stable
+identity.prerelease-users = []
+
 include file("/etc/gu/members-data-api.conf")


### PR DESCRIPTION
If we are to test the adfree feature live on the site, ad free capable users should be confined to the whitelist of dev accounts (which was previously provided). 

Reverts pull request: guardian/membership-attribute-service#47