### PR TITLE
Add content access details to `/user-attributes/me/membership`

### DIFF
--- a/membership-attribute-service/app/json/package.scala
+++ b/membership-attribute-service/app/json/package.scala
@@ -1,0 +1,16 @@
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{OWrites, Writes, _}
+
+
+package object json {
+  // Adapted from http://kailuowang.blogspot.co.uk/2013/11/addremove-fields-to-plays-default-case.html
+  implicit class RichOWrites[A](writes: OWrites[A]) {
+    def addField[T: Writes](fieldName: String, field: A => T): OWrites[A] =
+      (writes ~ (__ \ fieldName).write[T])((a: A) => (a, field(a)))
+
+    def removeField(fieldName: String): OWrites[A] = OWrites { a: A =>
+      val transformer = (__ \ fieldName).json.prune
+      Json.toJson(a)(writes).validate(transformer).get
+    }
+  }
+}

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -1,10 +1,17 @@
 package models
 
+import json._
 import play.api.libs.json._
 import play.api.mvc.Result
 import play.api.mvc.Results.Ok
 
 import scala.language.implicitConversions
+
+case class ContentAccess(member: Boolean, paidMember: Boolean)
+
+object ContentAccess {
+  implicit val jsWrite = Json.writes[ContentAccess]
+}
 
 case class Attributes(userId: String, tier: String, membershipNumber: Option[String]) {
   require(tier.nonEmpty)
@@ -12,10 +19,13 @@ case class Attributes(userId: String, tier: String, membershipNumber: Option[Str
 
   lazy val isFriendTier = tier.equalsIgnoreCase("friend")
   lazy val isPaidTier = !isFriendTier
+
+  lazy val contentAccess = ContentAccess(member = true, paidMember = isPaidTier) // we want to include staff!
 }
 
 object Attributes {
-  implicit val jsWrite = Json.writes[Attributes]
+  implicit val jsWrite: Writes[Attributes] =
+    Json.writes[Attributes].asInstanceOf[OWrites[Attributes]].addField("contentAccess", _.contentAccess)
 
   implicit def toResult(attrs: Attributes): Result =
     Ok(Json.toJson(attrs))

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -56,7 +56,8 @@ class AttributeControllerTest extends Specification {
         | {
         |   "tier": "patron",
         |   "membershipNumber": "abc",
-        |   "userId": "123"
+        |   "userId": "123",
+        |   "contentAccess":{"member":true,"paidMember":true}
         | }
       """.stripMargin)
   }


### PR DESCRIPTION
With `contentAccess` added, https://members-data-api.theguardian.com/user-attributes/me/membership will look like this:

```
 {
   "tier": "patron",
   "membershipNumber": "abc",
   "userId": "123",
   "contentAccess":{"member":true,"paidMember":true}
 }
```

This data is going under `/membership` rather than `/features` because it directly discloses that the user is a paying customer, which we're going to consider a piece of personal information.

Note also that we're going to want Staff to be able to see 'paid' member content, even though they don't pay.

https://trello.com/c/KhTyeT4p/193-restricted-content-change-user-me-endpoint-to-member-data-api

cc @ostapneko 