### PR TITLE
Don't block for EC2 Instance-Id Metadata

### DIFF
--- a/membership-attribute-service/app/filters/AddEC2InstanceHeader.scala
+++ b/membership-attribute-service/app/filters/AddEC2InstanceHeader.scala
@@ -10,11 +10,13 @@ import scala.concurrent.Future
 object AddEC2InstanceHeader extends Filter {
 
   // http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
-  lazy val instanceIdOptF = WS.url("http://169.254.169.254/latest/meta-data/instance-id").get().map(resp => Some(resp.body).filter(_.nonEmpty)).recover { case _ => None }
+  lazy val instanceIdF = WS.url("http://169.254.169.254/latest/meta-data/instance-id").get().map(_.body)
 
   def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = for {
     result <- nextFilter(requestHeader)
-    instanceIdOpt <- instanceIdOptF
-  } yield instanceIdOpt.fold(result)(instanceId => result.withHeaders("X-EC2-instance-id" -> instanceId))
+  } yield {
+    val instanceIdOpt = instanceIdF.value.flatMap(_.toOption) // We don't want to block if the value is not available
+    instanceIdOpt.fold(result)(instanceId => result.withHeaders("X-EC2-instance-id" -> instanceId))
+  }
 
 }


### PR DESCRIPTION
The `X-EC2-instance-id` header is useful for us when we trawl through Fastly access logs, and the EC2 metadata call only occurs once on start-up, but in the dev environment we restart frequently, and don't want to wait the 30-seconds or so it takes for the request to time-out!

The behaviour was a little strange to observe before we knew what was going on - we would curl http://localhost:9400/healthcheck, and the application log would immediately say a response had been returned:

```
2015-11-13 10:02:12,423 [ForkJoinPool-1-worker-1] INFO  play.api.Play$ - Application started (Dev)
2015-11-13 10:02:12,729 [application-akka.actor.default-dispatcher-6] INFO  filters.LogRequestsFilter$ - REQUEST 127.0.0.1 GET /healthcheck took 194 ms and returned 200
```

...but curl wouldn't return a response for at least half a minute!

Thanks to @ostapneko for investigating this with me :microscope: 