### PR TITLE
Support authentication through Identity Access Tokens as well as cookies

### DIFF
--- a/membership-attribute-service/app/services/IdentityAuthService.scala
+++ b/membership-attribute-service/app/services/IdentityAuthService.scala
@@ -2,11 +2,18 @@ package services
 
 import _root_.play.api.mvc.RequestHeader
 import com.gu.identity.play
+import com.gu.identity.play.{AccessCredentials, AuthenticatedIdUser}
 import configuration.Config
 
 object IdentityAuthService extends AuthenticationService {
   val playAuthService = new play.AuthenticationService {
     override val identityKeys = Config.idKeys
+
+    override lazy val authenticatedIdUserProvider =
+      AuthenticatedIdUser.provider(
+        AccessCredentials.Cookies.authProvider(identityKeys),
+        AccessCredentials.Token.authProvider(identityKeys,"members-data-api")
+      )
   }
 
   override def userId(implicit request: RequestHeader): Option[String] =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   //libraries
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.44"
-  val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.10"
+  val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.12"
   val identityTestUsers =  "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val playWS = PlayImport.ws


### PR DESCRIPTION
This is a re-do of https://github.com/guardian/membership-attribute-service/pull/51, this time with added `lazy vals` to stop class initialisation errors.

--
The Guardian mobile apps authenticate through Identity Access Tokens rather than Cookies (ie the SC_GU_U, etc cookies), and so we want to support the mobile clients on `members-data-api.theguardian.com`.

https://trello.com/c/d7jD8CUW/120-members-data-api-enable-access-by-mobile-access-tokens

See also https://github.com/guardian/identity-play-auth/pull/4