### PR TITLE
Allow the "origin" header safari sends along with CORS requests

### DIFF
--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -51,7 +51,7 @@ object Config {
   )
 
   lazy val mmaCardCorsConfig = Config.mmaCorsConfig.copy(
-    isHttpHeaderAllowed = Seq("accept", "content-type", "csrf-token").contains(_),
+    isHttpHeaderAllowed = Seq("accept", "content-type", "csrf-token", "origin").contains(_),
     isHttpMethodAllowed = _ == "POST",
     supportsCredentials = true
   )


### PR DESCRIPTION
I am struggling with their dev tools but I think they send origin during the preflight access-control-request-headers