### PR TITLE
Revert "Enable CloudWatch logs"

### DIFF
--- a/cloudformation/membership-attribute-service.json
+++ b/cloudformation/membership-attribute-service.json
@@ -291,9 +291,6 @@
           "Fn::Base64": {
             "Fn::Join": ["", [
               "#!/bin/bash -ev\n",
-
-              "CONF_DIR=/membership-attribute-service/membership-attribute-service-1.0-SNAPSHOT/conf",
-
               "aws s3 cp s3://gu-membership-attribute-service-dist/set-env.sh .\n",
               "chmod +x set-env.sh\n",
 
@@ -310,13 +307,6 @@
               {"Fn::Join":["", ["aws --region ", { "Ref": "AWS::Region" }, " s3 cp s3://members-data-api-private/", { "Ref" : "Stage" }, "/members-data-api.conf /etc/gu\n"]]},
               "chown membership-attribute-service /etc/gu/members-data-api.conf\n",
               "chmod 0600 /etc/gu/members-data-api.conf\n",
-
-              "wget https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py",
-              {"Fn::Join": ["", ["sed -i",
-                " -e \"s/__DATE/$(date +%F)/\"",
-                " -e 's/__STAGE/", { "Ref": "Stage" }, "/'",
-                " $CONF_DIR/logger.conf"]]},
-              {"Fn::Join": [" ", ["python awslogs-agent-setup.py -nr", { "Ref": "AWS::Region" }, "-c $CONF_DIR/logger.conf" ]]},
 
               "service membership-attribute-service start\n",
               "sleep 20s\n"

--- a/membership-attribute-service/conf/logger.conf
+++ b/membership-attribute-service/conf/logger.conf
@@ -1,8 +1,0 @@
-[general]
-state_file = /var/awslogs/agent-state
-
-[/membership-attribute-service/logs/membership-attribute-service.log]
-file = /membership-attribute-service/logs/membership-attribute-service.log
-log_group_name = MembershipAttributeService-__STAGE
-log_stream_name = __DATE/{instance_id}/membership-attribute-service.log
-datetime_format = %Y-%m-%d %H:%M-%S


### PR DESCRIPTION
Reverts guardian/membership-attribute-service#77

We were missing what turned out to be quite an important newline from the bash script