### PR TITLE
Add a logger.conf for cloudwatch

### DIFF
--- a/membership-attribute-service/conf/logger.conf
+++ b/membership-attribute-service/conf/logger.conf
@@ -1,0 +1,8 @@
+[general]
+state_file = /var/awslogs/agent-state
+
+[/membership-attribute-service/logs/membership-attribute-service.log]
+file = /membership-attribute-service/logs/membership-attribute-service.log
+log_group_name = MembershipAttributeService-__STAGE
+log_stream_name = __DATE/{instance_id}/membership-attribute-service.log
+datetime_format = %Y-%m-%d %H:%M-%S


### PR DESCRIPTION
We're soft deploying the logging by modifying the cloudformation in AWS but it fails due to this file not being in git