### PR TITLE
Make controllers singletons

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -12,17 +12,18 @@ import play.api.data.Form
 import play.api.data.Forms._
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
-import play.api.mvc.Result
+import play.api.mvc.{Controller, Result}
 import play.filters.cors.CORSActionBuilder
 import _root_.services.{AuthenticationService, IdentityAuthService}
 import models.AccountDetails._
 import scala.concurrent.Future
 import scalaz.OptionT
 import scalaz.std.scalaFuture._
-import play.api.mvc.Results.{Ok, Forbidden}
 import json.PaymentCardUpdateResultWriters._
 
-class AttributeController {
+object AttributeController extends AttributeController
+
+trait AttributeController extends Controller {
   
   lazy val authenticationService: AuthenticationService = IdentityAuthService
   lazy val mmaCorsFilter = CORSActionBuilder(Config.mmaCorsConfig)

--- a/membership-attribute-service/app/controllers/HealthCheckController.scala
+++ b/membership-attribute-service/app/controllers/HealthCheckController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import play.api.Logger
 import play.api.libs.json.Json
-import play.api.mvc.{Action, Results}
+import play.api.mvc.{Controller, Action, Results}
 import components.NormalTouchpointComponents
 import com.github.nscala_time.time.Imports._
 
@@ -16,7 +16,7 @@ class BoolTest(name: String, exec: () => Boolean) extends Test {
   override def ok = exec()
 }
 
-class HealthCheckController extends Results {
+object HealthCheckController extends Controller with Results {
   val zuora = NormalTouchpointComponents.zuoraService
 
   val tests: Seq[Test] = Seq(

--- a/membership-attribute-service/app/controllers/SalesforceHookController.scala
+++ b/membership-attribute-service/app/controllers/SalesforceHookController.scala
@@ -7,14 +7,13 @@ import parsers.Salesforce.{MembershipDeletion, MembershipUpdate, OrgIdMatchingEr
 import parsers.{Salesforce => SFParser}
 import play.Logger
 import play.api.libs.concurrent.Execution.Implicits._
-import play.api.mvc.BodyParsers.parse
-import play.api.mvc.Results.Ok
+import play.api.mvc.Controller
 
 import scala.Function.const
 import scala.concurrent.Future
 import scalaz.{-\/, \/-}
 
-class SalesforceHookController {
+object SalesforceHookController extends Controller {
   val metrics = CloudWatch("SalesforceHookController")
 
   private val ack = Ok(

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -1,16 +1,16 @@
 # Healthcheck
-GET        /healthcheck                                     @controllers.HealthCheckController.healthCheck
+GET        /healthcheck                                     controllers.HealthCheckController.healthCheck
 
-GET        /user-attributes/me/membership                   @controllers.AttributeController.membership
-GET        /user-attributes/me/features                     @controllers.AttributeController.features
+GET        /user-attributes/me/membership                   controllers.AttributeController.membership
+GET        /user-attributes/me/features                     controllers.AttributeController.features
 
-GET        /user-attributes/me/mma-digitalpack              @controllers.AttributeController.digitalPackDetails
-GET        /user-attributes/me/mma-membership               @controllers.AttributeController.membershipDetails
+GET        /user-attributes/me/mma-digitalpack              controllers.AttributeController.digitalPackDetails
+GET        /user-attributes/me/mma-membership               controllers.AttributeController.membershipDetails
 
-POST       /user-attributes/me/membership-update-card       @controllers.AttributeController.membershipUpdateCard
-OPTIONS    /user-attributes/me/membership-update-card       @controllers.AttributeController.membershipUpdateCard
+POST       /user-attributes/me/membership-update-card       controllers.AttributeController.membershipUpdateCard
+OPTIONS    /user-attributes/me/membership-update-card       controllers.AttributeController.membershipUpdateCard
 
-POST       /user-attributes/me/digitalpack-update-card      @controllers.AttributeController.digitalPackUpdateCard
-OPTIONS    /user-attributes/me/digitalpack-update-card      @controllers.AttributeController.digitalPackUpdateCard
+POST       /user-attributes/me/digitalpack-update-card      controllers.AttributeController.digitalPackUpdateCard
+OPTIONS    /user-attributes/me/digitalpack-update-card      controllers.AttributeController.digitalPackUpdateCard
 
-POST       /salesforce-hook                                 @controllers.SalesforceHookController.createAttributes
+POST       /salesforce-hook                                 controllers.SalesforceHookController.createAttributes

--- a/project/MembershipAttributeService.scala
+++ b/project/MembershipAttributeService.scala
@@ -61,7 +61,6 @@ trait MembershipAttributeService {
 object MembershipAttributeService extends Build with MembershipAttributeService {
   val api = app("membership-attribute-service")
                 .settings(libraryDependencies ++= apiDependencies)
-                .settings(routesGenerator := InjectedRoutesGenerator)
                 .settings(
                   addCommandAlias("devrun", "run -Dconfig.resource=DEV.conf 9400"),
                   addCommandAlias("batch-load", "runMain BatchLoader")


### PR DESCRIPTION
@rtyley @paulbrown1982 

Fixes runaway thread pool instantiation in CloudWatch class where each
request created a new thread pool at [CloudWatch.scala#L23](https://github.com/guardian/membership-attribute-service/blob/8a18590fd0a55bd0e46cd6489b62f261ef1f8a70/membership-attribute-service/app/monitoring/CloudWatch.scala#L23):

```
    val client = new AmazonCloudWatchAsyncClient(new DefaultAWSCredentialsProviderChain)
```