### PR TITLE
Less dramatic controller fix

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -12,18 +12,17 @@ import play.api.data.Form
 import play.api.data.Forms._
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
-import play.api.mvc.{Controller, Result}
+import play.api.mvc.Result
 import play.filters.cors.CORSActionBuilder
 import _root_.services.{AuthenticationService, IdentityAuthService}
 import models.AccountDetails._
 import scala.concurrent.Future
 import scalaz.OptionT
 import scalaz.std.scalaFuture._
+import play.api.mvc.Results.{Ok, Forbidden}
 import json.PaymentCardUpdateResultWriters._
 
-object AttributeController extends AttributeController
-
-trait AttributeController extends Controller {
+class AttributeController {
   
   lazy val authenticationService: AuthenticationService = IdentityAuthService
   lazy val mmaCorsFilter = CORSActionBuilder(Config.mmaCorsConfig)

--- a/membership-attribute-service/app/controllers/HealthCheckController.scala
+++ b/membership-attribute-service/app/controllers/HealthCheckController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import play.api.Logger
 import play.api.libs.json.Json
-import play.api.mvc.{Controller, Action, Results}
+import play.api.mvc.{Action, Results}
 import components.NormalTouchpointComponents
 import com.github.nscala_time.time.Imports._
 
@@ -16,7 +16,7 @@ class BoolTest(name: String, exec: () => Boolean) extends Test {
   override def ok = exec()
 }
 
-object HealthCheckController extends Controller with Results {
+class HealthCheckController extends Results {
   val zuora = NormalTouchpointComponents.zuoraService
 
   val tests: Seq[Test] = Seq(

--- a/membership-attribute-service/app/controllers/SalesforceHookController.scala
+++ b/membership-attribute-service/app/controllers/SalesforceHookController.scala
@@ -7,13 +7,14 @@ import parsers.Salesforce.{MembershipDeletion, MembershipUpdate, OrgIdMatchingEr
 import parsers.{Salesforce => SFParser}
 import play.Logger
 import play.api.libs.concurrent.Execution.Implicits._
-import play.api.mvc.Controller
+import play.api.mvc.BodyParsers.parse
+import play.api.mvc.Results.Ok
 
 import scala.Function.const
 import scala.concurrent.Future
 import scalaz.{-\/, \/-}
 
-object SalesforceHookController extends Controller {
+class SalesforceHookController {
   val metrics = CloudWatch("SalesforceHookController")
 
   private val ack = Ok(

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -1,16 +1,16 @@
 # Healthcheck
-GET        /healthcheck                                     controllers.HealthCheckController.healthCheck
+GET        /healthcheck                                     @controllers.HealthCheckController.healthCheck
 
-GET        /user-attributes/me/membership                   controllers.AttributeController.membership
-GET        /user-attributes/me/features                     controllers.AttributeController.features
+GET        /user-attributes/me/membership                   @controllers.AttributeController.membership
+GET        /user-attributes/me/features                     @controllers.AttributeController.features
 
-GET        /user-attributes/me/mma-digitalpack              controllers.AttributeController.digitalPackDetails
-GET        /user-attributes/me/mma-membership               controllers.AttributeController.membershipDetails
+GET        /user-attributes/me/mma-digitalpack              @controllers.AttributeController.digitalPackDetails
+GET        /user-attributes/me/mma-membership               @controllers.AttributeController.membershipDetails
 
-POST       /user-attributes/me/membership-update-card       controllers.AttributeController.membershipUpdateCard
-OPTIONS    /user-attributes/me/membership-update-card       controllers.AttributeController.membershipUpdateCard
+POST       /user-attributes/me/membership-update-card       @controllers.AttributeController.membershipUpdateCard
+OPTIONS    /user-attributes/me/membership-update-card       @controllers.AttributeController.membershipUpdateCard
 
-POST       /user-attributes/me/digitalpack-update-card      controllers.AttributeController.digitalPackUpdateCard
-OPTIONS    /user-attributes/me/digitalpack-update-card      controllers.AttributeController.digitalPackUpdateCard
+POST       /user-attributes/me/digitalpack-update-card      @controllers.AttributeController.digitalPackUpdateCard
+OPTIONS    /user-attributes/me/digitalpack-update-card      @controllers.AttributeController.digitalPackUpdateCard
 
-POST       /salesforce-hook                                 controllers.SalesforceHookController.createAttributes
+POST       /salesforce-hook                                 @controllers.SalesforceHookController.createAttributes

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -1,16 +1,16 @@
 # Healthcheck
-GET        /healthcheck                                     @controllers.HealthCheckController.healthCheck
+GET        /healthcheck                                     controllers.HealthCheckController.healthCheck
 
-GET        /user-attributes/me/membership                   @controllers.AttributeController.membership
-GET        /user-attributes/me/features                     @controllers.AttributeController.features
+GET        /user-attributes/me/membership                   controllers.AttributeController.membership
+GET        /user-attributes/me/features                     controllers.AttributeController.features
 
-GET        /user-attributes/me/mma-digitalpack              @controllers.AttributeController.digitalPackDetails
-GET        /user-attributes/me/mma-membership               @controllers.AttributeController.membershipDetails
+GET        /user-attributes/me/mma-digitalpack              controllers.AttributeController.digitalPackDetails
+GET        /user-attributes/me/mma-membership               controllers.AttributeController.membershipDetails
 
-POST       /user-attributes/me/membership-update-card       @controllers.AttributeController.membershipUpdateCard
-OPTIONS    /user-attributes/me/membership-update-card       @controllers.AttributeController.membershipUpdateCard
+POST       /user-attributes/me/membership-update-card       controllers.AttributeController.membershipUpdateCard
+OPTIONS    /user-attributes/me/membership-update-card       controllers.AttributeController.membershipUpdateCard
 
-POST       /user-attributes/me/digitalpack-update-card      @controllers.AttributeController.digitalPackUpdateCard
-OPTIONS    /user-attributes/me/digitalpack-update-card      @controllers.AttributeController.digitalPackUpdateCard
+POST       /user-attributes/me/digitalpack-update-card      controllers.AttributeController.digitalPackUpdateCard
+OPTIONS    /user-attributes/me/digitalpack-update-card      controllers.AttributeController.digitalPackUpdateCard
 
-POST       /salesforce-hook                                 @controllers.SalesforceHookController.createAttributes
+POST       /salesforce-hook                                 controllers.SalesforceHookController.createAttributes

--- a/project/MembershipAttributeService.scala
+++ b/project/MembershipAttributeService.scala
@@ -61,6 +61,7 @@ trait MembershipAttributeService {
 object MembershipAttributeService extends Build with MembershipAttributeService {
   val api = app("membership-attribute-service")
                 .settings(libraryDependencies ++= apiDependencies)
+                .settings(routesGenerator := InjectedRoutesGenerator)
                 .settings(
                   addCommandAlias("devrun", "run -Dconfig.resource=DEV.conf 9400"),
                   addCommandAlias("batch-load", "runMain BatchLoader")


### PR DESCRIPTION
So when you use play's _static_ routes generator the @ sign indicates you want your controllers to be classes with zero arguments

When you use the _injected_ routes generator however it indicates you want to use a provider function to get your controller instances, which is **re-run on every request**

From InjectedRoutesGenerator.scala
```scala
// If it's using the @ syntax, we depend on the provider (ie, look it up each time)
```

As such we can still use the InjectedRoutesGenerator and don't have to fall back to legacy static controllers if we just remove the @ signs from the routes file, which we did anyway as part of the fix.