### PR TITLE
Fix monthly downgrades

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import com.gu.memsub._
+import com.gu.services.model.PaymentDetails
 import configuration.Config
 import models.ApiError._
 import models.ApiErrors._
@@ -83,7 +84,9 @@ class AttributeController {
     (for {
       user <- OptionT(Future.successful(authenticationService.userId))
       contact <- OptionT(request.touchpoint.contactRepo.get(user))
-      details <- OptionT(request.touchpoint.paymentService.paymentDetails(contact))
+      sub <- OptionT(request.touchpoint.subscriptionService.getEither(contact))
+      details <- OptionT(request.touchpoint.paymentService.paymentDetails(sub).map[Option[PaymentDetails]](Some(_)))
+
     } yield (contact, details).toResult).run.map(_ getOrElse Ok(Json.obj()))
   }
 }

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -17,6 +17,11 @@ object AccountDetails {
         contact.regNumber.fold(Json.obj())({m => Json.obj("regNumber" -> m)})
 
     private def toJson(paymentDetails: PaymentDetails): JsObject = {
+
+      val endDate = paymentDetails.chargedThroughDate
+        .map(_.toDateTimeAtStartOfDay)
+        .getOrElse(paymentDetails.termEndDate)
+
       val card = paymentDetails.card.fold(Json.obj())(card => Json.obj(
         "card" -> Json.obj(
           "last4" -> card.last4,
@@ -29,7 +34,7 @@ object AccountDetails {
         "optIn" -> !paymentDetails.pendingCancellation,
         "subscription" -> (card ++ Json.obj(
           "start" -> paymentDetails.lastPaymentDate,
-          "end" -> paymentDetails.termEndDate,
+          "end" -> endDate,
           "nextPaymentPrice" -> paymentDetails.nextPaymentPrice,
           "nextPaymentDate" -> paymentDetails.nextPaymentDate,
           "renewalDate" -> paymentDetails.termEndDate,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val awsWrap = "com.github.dwhjames" %% "aws-wrap" % "0.7.2"
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.9.31"
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.9.31"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.169"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.170"
 
 
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"


### PR DESCRIPTION
Currently if you downgrade to a friend you're told your subscriber benefits will run out after the _term end date_ of your subscription. This is true for annual subscriptions where you're billed once per term but not for monthly subscriptions, where your benefits will run out after the end of your current charged period.